### PR TITLE
PoC: Mount CHAOSScon 2026 Europe content from chaoss/website

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,5 @@
+[submodule "external/chaoss-website"]
+	path = external/chaoss-website
+	url = https://github.com/chaoss/website.git
+	branch = main
+	shallow = true

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ This site uses [Hugo](https://gohugo.io/) as its templating engine to generate t
 
 Once hugo is installed, you can run `hugo serve` in this project's directory to start a local web server and preview the content.
 
+Some content is mounted from external repositories. To include the CHAOSScon proof-of-concept content, initialize submodules before building:
+
+```shell
+git submodule update --init --depth 1 --filter=blob:none external/chaoss-website
+git -C external/chaoss-website sparse-checkout set CHAOSScon/2026Europe
+```
+
 **Note about Offline Builds**
 Note about the build process: Some pages of the website, such as the CHAOSS charter, are fetched from other github repositories at build time using the GitHub API. If you do not have internet access when you first build the site, the builds will fail.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Some content is mounted from external repositories. To include the CHAOSScon pro
 
 ```shell
 git submodule update --init --depth 1 --filter=blob:none external/chaoss-website
-git -C external/chaoss-website sparse-checkout set CHAOSScon/2026Europe
+git -C external/chaoss-website sparse-checkout set CHAOSScon
 ```
 
 **Note about Offline Builds**

--- a/content/chaosscon/chaosscon-2026-eu.md
+++ b/content/chaosscon/chaosscon-2026-eu.md
@@ -1,5 +1,6 @@
 ---
 title: CHAOSScon-2026-EU
+draft: true
 author: elizabeth
 type: page
 date: 2025-10-06T17:18:21+00:00

--- a/hugo.toml
+++ b/hugo.toml
@@ -13,6 +13,116 @@ tagline = 'Metrics, Models & Software for Open Source Community Health'
 [markup.goldmark.renderer]
 unsafe = true
 
+[module]
+[[module.mounts]]
+source = 'archetypes'
+target = 'archetypes'
+
+[[module.mounts]]
+source = 'content'
+target = 'content'
+
+[[module.mounts]]
+source = 'static'
+target = 'static'
+
+[[module.mounts]]
+source = 'external/chaoss-website/CHAOSScon/2026Europe/about.md'
+target = 'content/chaosscon-2026-eu/_index.md'
+
+[[module.mounts]]
+source = 'external/chaoss-website/CHAOSScon/2026Europe/schedule.md'
+target = 'content/chaosscon-2026-eu/agenda.md'
+
+[[module.mounts]]
+source = 'external/chaoss-website/CHAOSScon/2026Europe/travel_info.md'
+target = 'content/chaosscon-2026-eu/travel.md'
+
+[[module.mounts]]
+source = 'external/chaoss-website/CHAOSScon/2026Europe/faq.md'
+target = 'content/chaosscon-2026-eu/faq.md'
+
+[[module.mounts]]
+source = 'external/chaoss-website/CHAOSScon/2026Europe/committee.md'
+target = 'content/chaosscon-2026-eu/committee.md'
+
+[[module.mounts]]
+source = 'external/chaoss-website/CHAOSScon/2026Europe/event_details.md'
+target = 'content/chaosscon-2026-eu/event-details.md'
+
+[[module.mounts]]
+source = 'external/chaoss-website/CHAOSScon/2026Europe/event_location_time.md'
+target = 'content/chaosscon-2026-eu/event-location-time.md'
+
+[[module.mounts]]
+source = 'external/chaoss-website/CHAOSScon/2026Europe/info_for_speakers.md'
+target = 'content/chaosscon-2026-eu/info-for-speakers.md'
+
+[[module.mounts]]
+source = 'external/chaoss-website/CHAOSScon/2026Europe/speakers.md'
+target = 'content/chaosscon-2026-eu/speakers.md'
+
+[[module.mounts]]
+source = 'external/chaoss-website/CHAOSScon/2026Europe/images'
+target = 'static/chaosscon-2026-eu/images'
+
+[[module.mounts]]
+source = 'external/chaoss-website/CHAOSScon/2026Europe/slides'
+target = 'static/chaosscon-2026-eu/slides'
+
+[[module.mounts]]
+source = 'external/chaoss-website/CHAOSScon/2026Europe/CHAOSScon.Europe.2026_funding_prospectus.docx'
+target = 'static/chaosscon-2026-eu/CHAOSScon.Europe.2026_funding_prospectus.docx'
+
+[[module.mounts]]
+source = 'external/chaoss-website/CHAOSScon/2026Europe/CHAOSScon.Europe.2026_funding_prospectus.pdf'
+target = 'static/chaosscon-2026-eu/CHAOSScon.Europe.2026_funding_prospectus.pdf'
+
+[[cascade]]
+title = 'CHAOSScon Europe 2026'
+[cascade.target]
+path = '/chaosscon-2026-eu'
+
+[[cascade]]
+title = 'Schedule and Speakers'
+[cascade.target]
+path = '/chaosscon-2026-eu/agenda'
+
+[[cascade]]
+title = 'Travel and Brussels Info'
+[cascade.target]
+path = '/chaosscon-2026-eu/travel'
+
+[[cascade]]
+title = 'Frequently Asked Questions'
+[cascade.target]
+path = '/chaosscon-2026-eu/faq'
+
+[[cascade]]
+title = 'Committee'
+[cascade.target]
+path = '/chaosscon-2026-eu/committee'
+
+[[cascade]]
+title = 'Event Details'
+[cascade.target]
+path = '/chaosscon-2026-eu/event-details'
+
+[[cascade]]
+title = 'Event Location and Time'
+[cascade.target]
+path = '/chaosscon-2026-eu/event-location-time'
+
+[[cascade]]
+title = 'Info for Speakers'
+[cascade.target]
+path = '/chaosscon-2026-eu/info-for-speakers'
+
+[[cascade]]
+title = 'Speakers'
+[cascade.target]
+path = '/chaosscon-2026-eu/speakers'
+
 [[menus.main]]
 name = 'Home'
 pageRef = '/'

--- a/hugo.toml
+++ b/hugo.toml
@@ -43,26 +43,6 @@ source = 'external/chaoss-website/CHAOSScon/2026Europe/faq.md'
 target = 'content/chaosscon-2026-eu/faq.md'
 
 [[module.mounts]]
-source = 'external/chaoss-website/CHAOSScon/2026Europe/committee.md'
-target = 'content/chaosscon-2026-eu/committee.md'
-
-[[module.mounts]]
-source = 'external/chaoss-website/CHAOSScon/2026Europe/event_details.md'
-target = 'content/chaosscon-2026-eu/event-details.md'
-
-[[module.mounts]]
-source = 'external/chaoss-website/CHAOSScon/2026Europe/event_location_time.md'
-target = 'content/chaosscon-2026-eu/event-location-time.md'
-
-[[module.mounts]]
-source = 'external/chaoss-website/CHAOSScon/2026Europe/info_for_speakers.md'
-target = 'content/chaosscon-2026-eu/info-for-speakers.md'
-
-[[module.mounts]]
-source = 'external/chaoss-website/CHAOSScon/2026Europe/speakers.md'
-target = 'content/chaosscon-2026-eu/speakers.md'
-
-[[module.mounts]]
 source = 'external/chaoss-website/CHAOSScon/2026Europe/images'
 target = 'static/chaosscon-2026-eu/images'
 
@@ -97,31 +77,6 @@ path = '/chaosscon-2026-eu/travel'
 title = 'Frequently Asked Questions'
 [cascade.target]
 path = '/chaosscon-2026-eu/faq'
-
-[[cascade]]
-title = 'Committee'
-[cascade.target]
-path = '/chaosscon-2026-eu/committee'
-
-[[cascade]]
-title = 'Event Details'
-[cascade.target]
-path = '/chaosscon-2026-eu/event-details'
-
-[[cascade]]
-title = 'Event Location and Time'
-[cascade.target]
-path = '/chaosscon-2026-eu/event-location-time'
-
-[[cascade]]
-title = 'Info for Speakers'
-[cascade.target]
-path = '/chaosscon-2026-eu/info-for-speakers'
-
-[[cascade]]
-title = 'Speakers'
-[cascade.target]
-path = '/chaosscon-2026-eu/speakers'
 
 [[menus.main]]
 name = 'Home'

--- a/hugo.toml
+++ b/hugo.toml
@@ -43,6 +43,10 @@ source = 'external/chaoss-website/CHAOSScon/2026Europe/faq.md'
 target = 'content/chaosscon-2026-eu/faq.md'
 
 [[module.mounts]]
+source = 'external/chaoss-website/CHAOSScon/2026Europe/event_location_time.md'
+target = 'content/chaosscon-2026-eu/event-location-time.md'
+
+[[module.mounts]]
 source = 'external/chaoss-website/CHAOSScon/2026Europe/images'
 target = 'static/chaosscon-2026-eu/images'
 
@@ -60,6 +64,8 @@ target = 'static/chaosscon-2026-eu/CHAOSScon.Europe.2026_funding_prospectus.pdf'
 
 [[cascade]]
 title = 'CHAOSScon Europe 2026'
+layout = 'chaosscon-home'
+event_location_content_path = 'external/chaoss-website/CHAOSScon/2026Europe/event_location_time.md'
 [cascade.target]
 path = '/chaosscon-2026-eu'
 
@@ -77,6 +83,12 @@ path = '/chaosscon-2026-eu/travel'
 title = 'Frequently Asked Questions'
 [cascade.target]
 path = '/chaosscon-2026-eu/faq'
+
+[[cascade]]
+[cascade.build]
+render = 'never'
+[cascade.target]
+path = '/chaosscon-2026-eu/event-location-time'
 
 [[menus.main]]
 name = 'Home'

--- a/themes/chaoss/layouts/_default/chaosscon-home.html
+++ b/themes/chaoss/layouts/_default/chaosscon-home.html
@@ -1,0 +1,23 @@
+{{ define "main" }}
+  <div class="page-header">
+    <div class="page-header-inner">
+      <h1>{{ .Title }}</h1>
+    </div>
+  </div>
+
+  <div class="section">
+    {{ with .Content }}
+      <div class="page-content" style="padding: 0 0 1.5rem;">
+        {{ . }}
+      </div>
+    {{ end }}
+
+    {{ with .Params.event_location_content_path }}
+      {{ with readFile . }}
+        <div class="page-content" style="padding: 0 0 1.5rem;">
+          {{ . | markdownify }}
+        </div>
+      {{ end }}
+    {{ end }}
+  </div>
+{{ end }}


### PR DESCRIPTION
## Summary

This is a proof of concept for importing CHAOSScon content from `chaoss/website` using a shallow Git submodule and Hugo mounts/cascade.

It follows the direction discussed in #15: start with a Git submodule approach first, validate the Hugo Mounts + Cascade pattern, and use `CHAOSScon/2026Europe` as the initial test case.

## What Changed

- Added `chaoss/website` as a shallow submodule under `external/chaoss-website`
- Mounted selected files from `CHAOSScon/2026Europe` into Hugo content routes
- Added cascade titles for mounted CHAOSScon pages
- Mounted upstream images/slides/prospectus files as static assets
- Marked the old WordPress-exported `chaosscon-2026-eu.md` page as draft to avoid URL collision
- Documented lightweight submodule setup in the README

## Generated Routes

This PoC generates:

- `/chaosscon-2026-eu/`
- `/chaosscon-2026-eu/agenda/`
- `/chaosscon-2026-eu/travel/`
- `/chaosscon-2026-eu/faq/`
- `/chaosscon-2026-eu/committee/`
- `/chaosscon-2026-eu/event-details/`
- `/chaosscon-2026-eu/event-location-time/`
- `/chaosscon-2026-eu/info-for-speakers/`
- `/chaosscon-2026-eu/speakers/`

## Testing

Tested locally with:

```sh
git submodule update --init --depth 1 --filter=blob:none external/chaoss-website
git -C external/chaoss-website sparse-checkout set CHAOSScon/2026Europe
hugo --cleanDestinationDir --printPathWarnings --printI18nWarnings
```

Build completed successfully.
Verified mounted content appears in generated output:

- Homepage contains `About CHAOSScon`
- Travel page contains `Visiting Brussels`
- FAQ page contains `Frequently Asked Questions`

## Screenshots
**Mounted CHAOSScon homepage**
<img width="1919" height="872" alt="chaosscon-homepage" src="https://github.com/user-attachments/assets/923e3e44-eea9-4b42-aa41-443f2d176397" />

**Mounted travel page**
<img width="1919" height="872" alt="chaosscon-travel-page" src="https://github.com/user-attachments/assets/1da6d7bd-f8f7-4f3c-806b-5784b1ec881a" />

**Build verification**
<img width="1463" height="520" alt="Screenshot 2026-05-08 033303" src="https://github.com/user-attachments/assets/f248eb7b-5e2b-4884-8339-3770391492c6" />

## Known Notes
The upstream `CHAOSScon/2026Europe/schedule.md` currently has a malformed HTML comment (`<--!` instead of `<!--`), so the agenda page renders that comment text. This PR leaves upstream content unchanged and focuses on proving the submodule + Hugo mount pattern.

The existing unrelated Hugo warning about duplicate `governance/index.html` still appears during build and is not introduced by this PR.
