### PR TITLE
Replace text logo with CHAOSS image logo

### DIFF
--- a/themes/chaoss/assets/css/main.css
+++ b/themes/chaoss/assets/css/main.css
@@ -84,27 +84,9 @@ img {
   color: var(--color-teal);
 }
 
-.site-brand .logo-text {
-  font-size: 1.5rem;
-  font-weight: 700;
-  letter-spacing: 1px;
-}
-
-.site-brand .logo-dot {
-  color: var(--color-teal);
-}
-
-.site-brand .logo-tagline {
-  font-size: 0.7rem;
-  color: var(--color-gray-500);
-  letter-spacing: 0.5px;
-  display: none;
-}
-
-@media (min-width: 768px) {
-  .site-brand .logo-tagline {
-    display: block;
-  }
+.site-brand img {
+  height: 40px;
+  width: auto;
 }
 
 /* Nav */

--- a/themes/chaoss/layouts/partials/header.html
+++ b/themes/chaoss/layouts/partials/header.html
@@ -1,9 +1,6 @@
 <div class="header-inner">
   <a href="{{ "/" | relURL }}" class="site-brand">
-    <div>
-      <span class="logo-text">CHAOSS<span class="logo-dot">.</span></span>
-      <span class="logo-tagline">{{ site.Params.tagline | default "Community Health Analytics in Open Source Software" }}</span>
-    </div>
+    <img src="{{ "/wp-content/uploads/2022/08/chaoss-white-2.png" | relURL }}" alt="CHAOSS Logo">
   </a>
   <button class="nav-toggle" aria-label="Toggle navigation" onclick="document.querySelector('.site-nav').classList.toggle('open')">&#9776;</button>
   {{ partial "menu.html" (dict "menuID" "main" "page" .) }}


### PR DESCRIPTION
Closes #4 

Restructured the header and added the logo

# Screenshots

## On the Wordpress site

<img width="1458" height="733" alt="image" src="https://github.com/user-attachments/assets/051159fb-c9f2-469c-98c7-45dd314b44a0" />


## On the Hugo site

<img width="2876" height="1384" alt="Screenshot 2026-05-10 at 18-16-36 Software CHAOSS" src="https://github.com/user-attachments/assets/3741aacd-b8ff-4579-8e84-0268d6fdbd7c" />
<img width="2878" height="1302" alt="Screenshot 2026-05-10 at 18-16-23 Governance CHAOSS" src="https://github.com/user-attachments/assets/c1e8144d-50b5-4dea-b1e2-d97581dc5770" />

<br>

@MoralCode let me know if any changes are needed