### PR TITLE
Cleanup kb-chaoss-community.md

### DIFF
--- a/content/kb-chaoss-community.md
+++ b/content/kb-chaoss-community.md
@@ -22,7 +22,7 @@ The CHAOSS community is dedicated to fostering an open and welcoming environment
 <div class="mkb-home-topics mkb-columns mkb-columns-2 mkb-uuid-69cb2c579bf91">
   <div class="mkb-row">
     <div class="kb-topic topic-id-189 kb-topic--box-view">
-      <a href="{{ baseURL }}kbtopic/how-to-contribute/"></p> 
+      <a href='{{< ref "kbtopic/how-to-contribute/" >}}'></p> 
       
       <div class="kb-topic__inner">
         <div class="kb-topic__box-header" style="color: #4a90e2;">
@@ -54,7 +54,7 @@ The CHAOSS community is dedicated to fostering an open and welcoming environment
         </a> </div> 
         
         <div class="kb-topic topic-id-190 kb-topic--box-view">
-          <a href="{{ baseURL }}kbtopic/templates/"></p> 
+          <a href='{{< ref "kbtopic/templates/" >}}'></p> 
           
           <div class="kb-topic__inner">
             <div class="kb-topic__box-header" style="color: #4a90e2;">
@@ -83,7 +83,7 @@ The CHAOSS community is dedicated to fostering an open and welcoming environment
             
             <div class="mkb-row">
               <div class="kb-topic topic-id-462 kb-topic--box-view">
-                <a href="{{ baseURL }}kbtopic/chaoss-groups/"></p> 
+                <a href='{{< ref "kbtopic/chaoss-groups/" >}}'></p> 
                 
                 <div class="kb-topic__inner">
                   <div class="kb-topic__box-header" style="color: #4a90e2;">
@@ -111,7 +111,7 @@ The CHAOSS community is dedicated to fostering an open and welcoming environment
                   </a> </div> 
                   
                   <div class="kb-topic topic-id-520 kb-topic--box-view">
-                    <a href="{{ baseURL }}kbtopic/media-and-outreach/"></p> 
+                    <a href='{{< ref "kbtopic/media-and-outreach/" >}}'></p> 
                     
                     <div class="kb-topic__inner">
                       <div class="kb-topic__box-header" style="color: #4a90e2;">
@@ -147,5 +147,5 @@ The CHAOSS community is dedicated to fostering an open and welcoming environment
                       </p>
 
  [1]: https://join.slack.com/t/chaoss-workspace/shared_invite/zt-28p56bayt-67TRjdA4yJWQmUd4hCzULg
- [2]: {{ baseURL }}kb-getting-started/
+ [2]: {{< ref "kb-getting-started/" >}}
  [3]: mailto:elizabeth@eb-tc.com

--- a/content/kb-chaoss-community.md
+++ b/content/kb-chaoss-community.md
@@ -9,11 +9,14 @@ nectar-metabox-portfolio-display-sortable:
   - off
 url: /kb-chaoss-community
 ---
-\[vc\_row type=&#8221;full\_width\_background&#8221; full\_screen\_row\_position=&#8221;middle&#8221; column\_margin=&#8221;default&#8221; column\_direction=&#8221;default&#8221; column\_direction\_tablet=&#8221;default&#8221; column\_direction\_phone=&#8221;default&#8221; bg\_color=&#8221;#edfaff&#8221; scene\_position=&#8221;center&#8221; text\_color=&#8221;dark&#8221; text\_align=&#8221;left&#8221; row\_border\_radius=&#8221;none&#8221; row\_border\_radius\_applies=&#8221;bg&#8221; overlay\_strength=&#8221;0.3&#8243; gradient\_direction=&#8221;left\_to\_right&#8221; shape\_divider\_position=&#8221;bottom&#8221; bg\_image\_animation=&#8221;none&#8221; shape\_type=&#8221;&#8221;\]\[vc\_column column\_padding=&#8221;padding-3-percent&#8221; column\_padding\_tablet=&#8221;inherit&#8221; column\_padding\_phone=&#8221;inherit&#8221; column\_padding\_position=&#8221;all&#8221; background\_color\_opacity=&#8221;1&#8243; background\_hover\_color\_opacity=&#8221;1&#8243; column\_shadow=&#8221;none&#8221; column\_border\_radius=&#8221;none&#8221; column\_link\_target=&#8221;\_self&#8221; gradient\_direction=&#8221;left\_to\_right&#8221; overlay\_strength=&#8221;0.3&#8243; width=&#8221;1/2&#8243; tablet\_width\_inherit=&#8221;default&#8221; tablet\_text\_alignment=&#8221;default&#8221; phone\_text\_alignment=&#8221;default&#8221; column\_border\_width=&#8221;none&#8221; column\_border\_style=&#8221;solid&#8221; bg\_image\_animation=&#8221;none&#8221;\][vc\_column_text]
 
 # <span style="color: #05b59f;">Join the CHAOSS Community</span>
 
-The CHAOSS community is dedicated to fostering an open and welcoming environment for contributors. Anyone can join our [Slack workspace][1], participate in Zoom meetings, or contribute to any of our projects at any time! Feel free to check out our [Quickstart for New Contributors][2] or, for more information about the CHAOSS community please reach out to our community manager, [Elizabeth Barron.][3]\[/vc\_column\_text\]\[/vc\_column\]\[vc\_column column\_padding=&#8221;no-extra-padding&#8221; column\_padding\_tablet=&#8221;inherit&#8221; column\_padding\_phone=&#8221;inherit&#8221; column\_padding\_position=&#8221;all&#8221; background\_color\_opacity=&#8221;1&#8243; background\_hover\_color\_opacity=&#8221;1&#8243; column\_shadow=&#8221;none&#8221; column\_border\_radius=&#8221;none&#8221; column\_link\_target=&#8221;\_self&#8221; gradient\_direction=&#8221;left\_to\_right&#8221; overlay\_strength=&#8221;0.3&#8243; width=&#8221;1/2&#8243; tablet\_width\_inherit=&#8221;default&#8221; tablet\_text\_alignment=&#8221;default&#8221; phone\_text\_alignment=&#8221;default&#8221; column\_border\_width=&#8221;none&#8221; column\_border\_style=&#8221;solid&#8221; bg\_image\_animation=&#8221;none&#8221;\]\[vc\_gallery type=&#8221;flexslider\_style&#8221; images=&#8221;5253,4873,5255,4964,5272,1520,1152,5375,5458,5493,5460&#8243; onclick=&#8221;link\_no&#8221;\]\[/vc\_column\]\[/vc\_row\]\[vc\_row type=&#8221;full\_width\_background&#8221; full\_screen\_row\_position=&#8221;middle&#8221; column\_margin=&#8221;default&#8221; column\_direction=&#8221;default&#8221; column\_direction\_tablet=&#8221;default&#8221; column\_direction\_phone=&#8221;default&#8221; bg\_color=&#8221;#ffffff&#8221; scene\_position=&#8221;center&#8221; text\_color=&#8221;dark&#8221; text\_align=&#8221;left&#8221; row\_border\_radius=&#8221;none&#8221; row\_border\_radius\_applies=&#8221;bg&#8221; overlay\_strength=&#8221;0.3&#8243; gradient\_direction=&#8221;left\_to\_right&#8221; shape\_divider\_position=&#8221;bottom&#8221; bg\_image\_animation=&#8221;none&#8221; shape\_type=&#8221;&#8221;\]\[vc\_column column\_padding=&#8221;no-extra-padding&#8221; column\_padding\_tablet=&#8221;inherit&#8221; column\_padding\_phone=&#8221;inherit&#8221; column\_padding\_position=&#8221;all&#8221; background\_color\_opacity=&#8221;1&#8243; background\_hover\_color\_opacity=&#8221;1&#8243; column\_shadow=&#8221;none&#8221; column\_border\_radius=&#8221;none&#8221; column\_link\_target=&#8221;\_self&#8221; gradient\_direction=&#8221;left\_to\_right&#8221; overlay\_strength=&#8221;0.3&#8243; width=&#8221;3/4&#8243; tablet\_width\_inherit=&#8221;default&#8221; tablet\_text\_alignment=&#8221;default&#8221; phone\_text\_alignment=&#8221;default&#8221; column\_border\_width=&#8221;none&#8221; column\_border\_style=&#8221;solid&#8221; bg\_image\_animation=&#8221;none&#8221;\]\[vc\_widget\_sidebar sidebar\_id=&#8221;page-sidebar&#8221;\]\[vc\_row\_inner column\_margin=&#8221;default&#8221; column\_direction=&#8221;default&#8221; column\_direction\_tablet=&#8221;default&#8221; column\_direction\_phone=&#8221;default&#8221; text\_align=&#8221;left&#8221;\]\[vc\_column\_inner column\_padding=&#8221;no-extra-padding&#8221; column\_padding\_tablet=&#8221;inherit&#8221; column\_padding\_phone=&#8221;inherit&#8221; column\_padding\_position=&#8221;all&#8221; background\_color\_opacity=&#8221;1&#8243; background\_hover\_color\_opacity=&#8221;1&#8243; column\_shadow=&#8221;none&#8221; column\_border\_radius=&#8221;none&#8221; column\_link\_target=&#8221;\_self&#8221; gradient\_direction=&#8221;left\_to\_right&#8221; overlay\_strength=&#8221;0.3&#8243; width=&#8221;1/1&#8243; tablet\_width\_inherit=&#8221;default&#8221; column\_border\_width=&#8221;none&#8221; column\_border\_style=&#8221;solid&#8221; bg\_image\_animation=&#8221;none&#8221;\]\[/vc\_column\_inner\]\[/vc\_row\_inner\]\[/vc\_column\]\[/vc\_row\]\[vc\_row type=&#8221;full\_width\_background&#8221; full\_screen\_row\_position=&#8221;middle&#8221; column\_margin=&#8221;default&#8221; column\_direction=&#8221;default&#8221; column\_direction\_tablet=&#8221;default&#8221; column\_direction\_phone=&#8221;default&#8221; bg\_color=&#8221;#ffffff&#8221; scene\_position=&#8221;center&#8221; top\_padding=&#8221;20&#8243; text\_color=&#8221;dark&#8221; text\_align=&#8221;left&#8221; row\_border\_radius=&#8221;none&#8221; row\_border\_radius\_applies=&#8221;bg&#8221; overlay\_strength=&#8221;0.3&#8243; gradient\_direction=&#8221;left\_to\_right&#8221; shape\_divider\_position=&#8221;bottom&#8221; bg\_image\_animation=&#8221;none&#8221; shape\_type=&#8221;&#8221;\][vc\_column column\_padding=&#8221;no-extra-padding&#8221; column\_padding\_tablet=&#8221;inherit&#8221; column\_padding\_phone=&#8221;inherit&#8221; column\_padding\_position=&#8221;all&#8221; background\_color\_opacity=&#8221;1&#8243; background\_hover\_color\_opacity=&#8221;1&#8243; column\_shadow=&#8221;none&#8221; column\_border\_radius=&#8221;none&#8221; column\_link\_target=&#8221;\_self&#8221; gradient\_direction=&#8221;left\_to\_right&#8221; overlay\_strength=&#8221;0.3&#8243; width=&#8221;3/4&#8243; tablet\_width\_inherit=&#8221;default&#8221; tablet\_text\_alignment=&#8221;default&#8221; phone\_text\_alignment=&#8221;default&#8221; column\_border\_width=&#8221;none&#8221; column\_border\_style=&#8221;solid&#8221; bg\_image\_animation=&#8221;none&#8221;]			<span class="mkb-shortcode-container"></p> 
+The CHAOSS community is dedicated to fostering an open and welcoming environment for contributors. Anyone can join our [Slack workspace][1], participate in Zoom meetings, or contribute to any of our projects at any time! Feel free to check out our [Quickstart for New Contributors][2] or, for more information about the CHAOSS community please reach out to our community manager, [Elizabeth Barron.][3]
+
+<!-- Search the CHAOSS website widget here -->
+
+<span class="mkb-shortcode-container"></p> 
 
 <div class="mkb-section-title" style="color:#333333;font-size:3em;">
   Topic Areas
@@ -22,130 +25,106 @@ The CHAOSS community is dedicated to fostering an open and welcoming environment
 <div class="mkb-home-topics mkb-columns mkb-columns-2 mkb-uuid-69cb2c579bf91">
   <div class="mkb-row">
     <div class="kb-topic topic-id-189 kb-topic--box-view">
-      <a href='{{< ref "kbtopic/how-to-contribute/" >}}'></p> 
-      
-      <div class="kb-topic__inner">
-        <div class="kb-topic__box-header" style="color: #4a90e2;">
-          <div class="kb-topic__icon-holder" style="padding-top: 0;padding-bottom: 0;">
-            <i class="kb-topic__box-icon fa fa-list-alt"></i>
-          </div>
-          
-          <h3 class="kb-topic__title" style="color: #4a90e2;">
-            How to Contribute
-          </h3></p>
-        </div>
-        
-        <div class="kb-topic__articles">
-          <div class="kb-topic__description">
-            Learn how to participate in the CHAOSS Community!
-          </div>
-          
-          <div class="kb-topic__box-count">
-            4 articles
-          </div>
-          
-          <div class="kb-topic__show-all">
-            Show all
-          </div></p>
-        </div></p>
-      </div>
-      
-      <p>
-        </a> </div> 
-        
-        <div class="kb-topic topic-id-190 kb-topic--box-view">
-          <a href='{{< ref "kbtopic/templates/" >}}'></p> 
-          
-          <div class="kb-topic__inner">
-            <div class="kb-topic__box-header" style="color: #4a90e2;">
-              <div class="kb-topic__icon-holder" style="padding-top: 0;padding-bottom: 0;">
-                <i class="kb-topic__box-icon fa fa-list-alt"></i>
-              </div>
-              
-              <h3 class="kb-topic__title" style="color: #4a90e2;">
-                Community Templates
-              </h3></p>
+      <a href='{{ baseURL }}kbtopic/how-to-contribute/'>
+        <div class="kb-topic__inner">
+          <div class="kb-topic__box-header" style="color: #4a90e2;">
+            <div class="kb-topic__icon-holder" style="padding-top: 0;padding-bottom: 0;">
+              <i class="kb-topic__box-icon fa fa-list-alt"></i>
             </div>
-            
-            <div class="kb-topic__articles">
-              <div class="kb-topic__box-count">
-                7 articles
-              </div>
-              
-              <div class="kb-topic__show-all">
-                Show all
-              </div></p>
-            </div></p>
+            <h3 class="kb-topic__title" style="color: #4a90e2;">
+              How to Contribute
+            </h3>
           </div>
-          
-          <p>
-            </a> </div> </div > 
-            
-            <div class="mkb-row">
-              <div class="kb-topic topic-id-462 kb-topic--box-view">
-                <a href='{{< ref "kbtopic/chaoss-groups/" >}}'></p> 
-                
-                <div class="kb-topic__inner">
-                  <div class="kb-topic__box-header" style="color: #4a90e2;">
-                    <div class="kb-topic__icon-holder" style="padding-top: 0;padding-bottom: 0;">
-                      <i class="kb-topic__box-icon fa fa-list-alt"></i>
-                    </div>
-                    
-                    <h3 class="kb-topic__title" style="color: #4a90e2;">
-                      CHAOSS Groups
-                    </h3></p>
-                  </div>
-                  
-                  <div class="kb-topic__articles">
-                    <div class="kb-topic__box-count">
-                      3 articles
-                    </div>
-                    
-                    <div class="kb-topic__show-all">
-                      Show all
-                    </div></p>
-                  </div></p>
-                </div>
-                
-                <p>
-                  </a> </div> 
-                  
-                  <div class="kb-topic topic-id-520 kb-topic--box-view">
-                    <a href='{{< ref "kbtopic/media-and-outreach/" >}}'></p> 
-                    
-                    <div class="kb-topic__inner">
-                      <div class="kb-topic__box-header" style="color: #4a90e2;">
-                        <div class="kb-topic__icon-holder" style="padding-top: 0;padding-bottom: 0;">
-                          <i class="kb-topic__box-icon fa fa-list-alt"></i>
-                        </div>
-                        
-                        <h3 class="kb-topic__title" style="color: #4a90e2;">
-                          Media and Outreach
-                        </h3></p>
-                      </div>
-                      
-                      <div class="kb-topic__articles">
-                        <div class="kb-topic__description">
-                          Brand Guidelines and Social Media Info
-                        </div>
-                        
-                        <div class="kb-topic__box-count">
-                          2 articles
-                        </div>
-                        
-                        <div class="kb-topic__show-all">
-                          Show all
-                        </div></p>
-                      </div></p>
-                    </div>
-                    
-                    <p>
-                      </a> </div> </div > </div> 
-                      
-                      <p>
-                        </span>[/vc_column][/vc_row]
-                      </p>
+          <div class="kb-topic__articles">
+            <div class="kb-topic__description">
+              Learn how to participate in the CHAOSS Community!
+            </div>
+            <div class="kb-topic__box-count">
+              4 articles
+            </div>
+            <div class="kb-topic__show-all">
+              Show all
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    <div class="kb-topic topic-id-190 kb-topic--box-view">
+      <a href='{{ baseURL }}kbtopic/templates/'>
+        <div class="kb-topic__inner">
+          <div class="kb-topic__box-header" style="color: #4a90e2;">
+            <div class="kb-topic__icon-holder" style="padding-top: 0;padding-bottom: 0;">
+              <i class="kb-topic__box-icon fa fa-list-alt"></i>
+            </div>
+            <h3 class="kb-topic__title" style="color: #4a90e2;">
+              Community Templates
+            </h3>
+          </div>
+          <div class="kb-topic__articles">
+            <div class="kb-topic__box-count">
+              7 articles
+            </div>
+            <div class="kb-topic__show-all">
+              Show all
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+  </div>
+
+  <div class="mkb-row">
+    <div class="kb-topic topic-id-462 kb-topic--box-view">
+      <a href='{{ baseURL }}kbtopic/chaoss-groups/'>
+        <div class="kb-topic__inner">
+          <div class="kb-topic__box-header" style="color: #4a90e2;">
+            <div class="kb-topic__icon-holder" style="padding-top: 0;padding-bottom: 0;">
+              <i class="kb-topic__box-icon fa fa-list-alt"></i>
+            </div>
+            <h3 class="kb-topic__title" style="color: #4a90e2;">
+              CHAOSS Groups
+            </h3>
+          </div>
+          <div class="kb-topic__articles">
+            <div class="kb-topic__box-count">
+              3 articles
+            </div>
+            <div class="kb-topic__show-all">
+              Show all
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+    <div class="kb-topic topic-id-520 kb-topic--box-view">
+      <a href='{{ baseURL }}kbtopic/media-and-outreach/'>
+        <div class="kb-topic__inner">
+          <div class="kb-topic__box-header" style="color: #4a90e2;">
+            <div class="kb-topic__icon-holder" style="padding-top: 0;padding-bottom: 0;">
+              <i class="kb-topic__box-icon fa fa-list-alt"></i>
+            </div>
+            <h3 class="kb-topic__title" style="color: #4a90e2;">
+              Media and Outreach
+            </h3>
+          </div>
+          <div class="kb-topic__articles">
+            <div class="kb-topic__description">
+              Brand Guidelines and Social Media Info
+            </div>
+            <div class="kb-topic__box-count">
+              2 articles
+            </div>
+            <div class="kb-topic__show-all">
+              Show all
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+  </div>
+</div>
+
 
  [1]: https://join.slack.com/t/chaoss-workspace/shared_invite/zt-28p56bayt-67TRjdA4yJWQmUd4hCzULg
- [2]: {{< ref "kb-getting-started/" >}}
+ [2]: {{< ref "quickstart" >}}
  [3]: mailto:elizabeth@eb-tc.com


### PR DESCRIPTION
This PR updates internal content links in `kb-chaoss-community.md` to use Hugo `ref` syntax instead of `{{ baseURL }}` references.
Changes were intentionally limited to a small validation scope as discussed in #29, to confirm the migration strategy works consistently before applying broader repository wide replacements.
