### PR TITLE
Add Hugo alias for old code of conduct URL

### DIFF
--- a/content/governance/code-of-conduct.md
+++ b/content/governance/code-of-conduct.md
@@ -10,6 +10,8 @@ nectar-metabox-portfolio-display-sortable:
   - off
 ppma_authors_name:
   - CHAOSS Community
+aliases:
+  - /about/code-of-conduct/
 url: /code-of-conduct
 params:
   content_repo: chaoss/.github


### PR DESCRIPTION
This PR adds a Hugo `aliases` entry for `/about/code-of-conduct/` to preserve the older Code of Conduct URL and redirect it to the current page location.
This follows the approach discussed in #8 for maintaining compatibility with legacy links.
